### PR TITLE
fix: YL-43-GitWorkflow-BugFix-WrongLabels-Back

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,20 +1,24 @@
 ci/cd:
 - changed-files:
-  - any-glob-to-any-files: .github/*
-  - all-globs-to-all-files: ['!.github/PULL_REQUEST_TEMPLATE.md', '!.github/semantic.yml', '!.github/labeler.yml', '!.github/workflows/pr-labeler.yml', '!.github/workflows/pr-semantic.yml']
+  - any-glob-to-any-files: .github/**
+  - all-globs-to-all-files: ['!.github/PULL_REQUEST_TEMPLATE.md', '!.github/labeler.yml', '!.github/workflows/pr-labeler.yml']
 
 tables:
 - changed-files:
-  - any-glob-to-any-files: prisma/*
+  - any-glob-to-any-files: prisma/**
 
 crud:
 - changed-files:
-  - any-glob-to-any-files: src/*
+  - any-glob-to-any-files: src/**
 
 tests:
 - changed-files:
-  - any-glob-to-any-files: test/*
+  - any-glob-to-any-files: test/**
 
 gitWorkflow:
 - changed-files:
-  - all-globs-to-all-files: ['.github/PULL_REQUEST_TEMPLATE.md', '.github/semantic.yml', '.github/labeler.yml', '.github/workflows/pr-labeler.yml', '.github/workflows/pr-semantic.yml']
+  - all-globs-to-all-files: ['.github/PULL_REQUEST_TEMPLATE.md', '.github/labeler.yml', '.github/workflows/pr-labeler.yml']
+
+Documentation:
+- changed-files:
+  - any-glob-to-any-files: '**/*.md'

--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -20,3 +20,4 @@ types: # default: feat | fix | docs | style | refactor | perf | test | build | c
   - chore
   - revert
   - gitWorkflow
+  - security

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -36,15 +36,15 @@ jobs:
             sizes: >
               {
                 "0": "XS",
-                "30": "S",
+                "20": "S",
                 "50": "M",
-                "100": "L",
-                "250": "XL"
+                "200": "L",
+                "500": "XL"
               }
 
   comment:
     runs-on: ubuntu-latest
     needs: size-label
-    if: ${{ contains(needs.size-label.outputs.label, 'XS') }}
+    if: ${{ contains(needs.size-label.outputs.label, 'XL') }}
     steps:
-      - run: echo "Too short PR"    
+      - run: echo "Too big PR"    

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -4,7 +4,7 @@ on:
 - pull_request_target
 
 jobs:
-  label:
+  labeler:
 
     runs-on: ubuntu-latest
     permissions:
@@ -12,9 +12,9 @@ jobs:
       pull-requests: write
 
     steps:
-    - uses: actions/labeler@v4
+    - uses: actions/labeler@v5
       with:
-        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        repo-token: "${{ secrets.YLB_ACSEC }}"
 
   size-label:
 
@@ -31,7 +31,7 @@ jobs:
           id: label
           uses: "pascalgn/size-label-action@v0.5.4"
           env:
-            GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+            GITHUB_TOKEN: "${{ secrets.YLB_ACSEC }}"
           with:
             sizes: >
               {


### PR DESCRIPTION
## WHAT
- Labeler action has upgraded from v4 to v5 for apply config in `labeler.yml` file.
- Secret token for Github action has defined in settings and added to repository.
- Documentation label has added

## WHY
Fix the bug where all labels had affected while the files concerned had not been changed.

## HOW
- Upgraded from version 4 to 5
```yaml
- uses: actions/labeler@v5
```
- I consulted the Anoosh blog medium for the Github token settings (see the link of reference in resources)
- Tested with other repository.
- I found a label type error during the verification on the current branch. This is because the action must be on the default branch, main in our case (see the link of the issue consulted in the Resources section)
- Check will fail for this PR but will be functional once this branch merged

### Link to Jira ticket
[YL-43 GitWorkflow-BugFix-WrongLabels-Back](https://youlinks.atlassian.net/browse/YL-43?atlOrigin=eyJpIjoiMjBhZWJiYWM3MWIwNGRmZTk4ODA0ZjdlMzE0YWQ1ZjgiLCJwIjoiaiJ9)
---

## Checklist
- [x] Tested
- [ ] Documented or commented
- [x] Search for duplicates code or PRs or issues
- [ ] Blocked
- [ ] WIP
---

## Blocked
N/A

## WIP
N/A
---

## Resources
Seetings of Github token :
[Automate GitHub PR Labeling with the Labeler Action](https://medium.com/@anooshmangalath/automate-github-pr-labeling-with-the-labeler-action-47b43041b325)
Issue in repository of Labeler :
[Error: found unexpected type for label 'xxx' (should be array of config options)](https://github.com/actions/labeler/issues/712)

┆Issue is synchronized with this [Jira Task](https://youlinks.atlassian.net/browse/YL-52) by [Unito](https://www.unito.io)
