### PR TITLE
feat: YL-19-LikedTagTable

### DIFF
--- a/.git-commit-template
+++ b/.git-commit-template
@@ -12,7 +12,7 @@
 
 # Footer:
 # Reviewed by: <name>
-# Include Github issue
+# Include Jira issue
 
 # ---COMMIT END---
 # Type can be

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,7 +12,8 @@ Copy the link here.
 ---
 
 ## Checklist
-- [ ] Tested
+- [ ] Manually tested
+- [ ] Automatically tested
 - [ ] Documented or commented
 - [ ] Search for duplicates code or PRs or issues
 - [ ] Blocked
@@ -24,7 +25,15 @@ If blocked, explain what is the problem and what is needed to unblock.
 
 ## WIP
 If the work is in progress, explain what is missing.
----
+
+## TODO
+tasks to be carried out in the near future in connection with this branch (attach the relevant tickets if necessary).
+
+## Bonus
+Additional tasks carried out in parallel (e.g. updating the CI, new Github settings, etc.)
+
+## Annex
+Attachments illustrating the developments carried out (images, code examples, etc.)
 
 ## Resources
 Useful links or attachments ?

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -19,3 +19,7 @@ Documentation:
   - any-glob-to-any-file: 
     - '**/*.md'
     - 'docs/**'
+
+Root:
+- changed-files:
+  - any-glob-to-any-file: '*'

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,7 +1,7 @@
 name: "Pull Request Labeler"
 
 on: 
-- pull_request
+- pull_request_target
 
 jobs:
   labeler:

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,7 +1,7 @@
 name: "Pull Request Labeler"
 
 on: 
-- pull_request_target
+- pull_request
 
 jobs:
   labeler:

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -18,6 +18,7 @@ model User {
   hashRefreshToken String?       @db.VarChar(300)
   refreshExpiresAt DateTime?
   likes           Liked[]
+  likedTags       LikedTag[]
   followers       Subscription[] @relation("follow")
   subscriptions   Subscription[] @relation("subscription")
   youtuber        Youtuber?
@@ -42,12 +43,22 @@ model Liked {
   @@id(name: "likedId", [userId, categoryId])
 }
 
+model LikedTag {
+  userId Int
+  tagId  Int
+  tag    Tags @relation(fields: [tagId], references: [id], onDelete: Cascade)
+  user   User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@id(name: "likedTagId", [userId, tagId])
+}
+
 model Tags {
   id         Int      @id @default(autoincrement())
   name       String   @unique
   userId     Int
   categoryId Int
   category   Category @relation(fields: [categoryId], references: [id], onDelete: Cascade)
+  likedTag   LikedTag[]
   user       User     @relation(fields: [userId], references: [id], onDelete: Cascade)
 }
 

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -10,6 +10,7 @@ import { AuthModule } from './authentification/auth.module';
 import { TagsModule } from './tags/tag.module';
 import { SubscriptionModule } from './subscription/subcription.module';
 import { ConfigModule } from '@nestjs/config';
+import { LikedTagModule } from './likedTag/likedTag.module';
 
 // GUARDS
 import { APP_GUARD } from '@nestjs/core';
@@ -31,6 +32,7 @@ import { PrismaService } from './prisma.service';
     TagsModule,
     SubscriptionModule,
     AuthModule,
+    LikedTagModule
   ],
   controllers: [],
   providers: [PrismaService,

--- a/src/likedTag/controller/likedTag.controller.ts
+++ b/src/likedTag/controller/likedTag.controller.ts
@@ -1,0 +1,38 @@
+import { Controller, Get, Put, Param, ParseIntPipe } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { LikedTagService } from '../service/likedTag.service';
+
+@ApiTags('LIKED_TAG')
+@Controller('likedTag')
+export class LikedTagController {
+    constructor(
+        private readonly likedTagService: LikedTagService,
+    ) { }
+
+    @Get('UserWhoLikeATag/:tagId')
+    async findUsersWhoLikedTag(@Param('tagId', ParseIntPipe) tagId: number): Promise<any> {
+        return await this.likedTagService.findUsersWhoLikedTagById(tagId);
+    }
+
+    @Get('TagsLikedByUserId/:userId')
+    async findTagsLikedByUser(@Param('userId', ParseIntPipe) userId: number): Promise<any> {
+        return await this.likedTagService.findTagsLikedByUserId(userId);
+    }
+
+    @Get('TagsLikedByUserName/:userName')
+    async findTagsLikedByUserName(@Param('userName') userName: string): Promise<any> {
+        return await this.likedTagService.findTagsLikedByUserName(userName);
+    }
+
+    @Get('UsersWhoLikeByTagName/:tagName')
+    async findUsersWhoLikedByTagName(@Param('tagName') tagName: string): Promise<any> {
+        return await this.likedTagService.findUsersWhoLikedByTagName(tagName);
+    }
+
+    @Put('likeOrUnlike/:userId/:tagId')
+    async toggleTagLike(
+        @Param('userId', ParseIntPipe) userId: number,
+        @Param('tagId', ParseIntPipe) tagId: number): Promise<any> {
+        return await this.likedTagService.toggleTagLike(userId, tagId);
+    }
+}

--- a/src/likedTag/likedTag.module.ts
+++ b/src/likedTag/likedTag.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+import { LikedTagController } from './controller/likedTag.controller';
+import { LikedTagService } from './service/likedTag.service';
+import { PrismaService } from 'src/prisma.service';
+import { UserModule } from 'src/user/user.module';
+import { TagsModule } from 'src/tags/tag.module';
+
+@Module({
+    providers: [PrismaService, LikedTagService],
+    controllers: [LikedTagController],
+    exports: [],
+    imports: []
+})
+export class LikedTagModule {
+}

--- a/src/likedTag/service/likedTag.service.ts
+++ b/src/likedTag/service/likedTag.service.ts
@@ -1,0 +1,116 @@
+import { BadRequestException, Injectable } from '@nestjs/common';
+import { PrismaService } from 'src/prisma.service';
+
+@Injectable()
+export class LikedTagService {
+    private readonly prisma = new PrismaService();
+
+    async findUsersWhoLikedTagById(tagId: number) {
+        return await this.prisma.likedTag.findMany({
+            where: {
+                tagId: tagId
+            },
+            select: {
+                user: true
+            }
+        });
+    }
+
+    async findTagsLikedByUserId(userId: number) {
+        return await this.prisma.likedTag.findMany({
+            where: {
+                userId: userId
+            },
+            select: {
+                tag: true
+            }
+        });
+    }
+
+    async findUsersWhoLikedByTagName(tagName: string) {
+        const tag = await this.prisma.tags.findUnique({ where: { name: tagName } });
+        if (!tag) {
+            throw new BadRequestException('Tag not found');
+        }
+        return await this.prisma.likedTag.findMany({
+            where: {
+                tagId: tag.id
+            },
+            select: {
+                user: {
+                    select: {
+                        userName: true
+                    }
+                }
+            }
+        });
+    }
+
+    async toggleTagLike(userId: number, tagId: number) {
+        const existingLike = await this.prisma.likedTag.findUnique({
+            where: {
+                likedTagId: {
+                    userId,
+                    tagId,
+                }
+            },
+            select: {
+                user: {
+                    select: {
+                        userName: true
+                    }
+                },
+                tag: {
+                    select: {
+                        name: true
+                    }
+                }
+            }
+        });
+
+        if (existingLike) {
+            return await this.prisma.likedTag.delete({
+                where: {
+                    likedTagId: {
+                        userId,
+                        tagId,
+                    },
+                }
+            });
+        } else {
+            return await this.prisma.likedTag.create({
+                data: {
+                    userId,
+                    tagId,
+                },
+                select: {
+                    user: {
+                        select: {
+                            userName: true
+                        }
+                    },
+                    tag: {
+                        select: {
+                            name: true
+                        }
+                    }
+                }
+            });
+        }
+    }
+
+    async findTagsLikedByUserName(userName: string) {
+        const user = await this.prisma.user.findUnique({ where: { userName } });
+        if (!user) {
+            throw new BadRequestException('User not found');
+        }
+        return await this.prisma.likedTag.findMany({
+            where: {
+                userId: user.id
+            },
+            select: {
+                tag: true
+            }
+        });
+    }
+}

--- a/src/user/dto/userData.dto.ts
+++ b/src/user/dto/userData.dto.ts
@@ -30,7 +30,7 @@ export class CreateUserDto {
     @ApiProperty()
     @IsString()
     @IsOptional()
-    urlLikendin?: string;
+    urlLinkedin?: string;
 }
 
 export class UserIsYoutuber {

--- a/src/user/service/user.service.ts
+++ b/src/user/service/user.service.ts
@@ -149,7 +149,7 @@ export class UserService {
 
         //TODO comment gérer les recommandations linkedins pendant la créations?
         const professionalData = userData.is_Professional
-            ? { create: { urlLinkedin: userData.urlLikendin, recommandationLinkedin: {} } }
+            ? { create: { urlLinkedin: userData.urlLinkedin, recommandationLinkedin: {} } }
             : undefined;
 
         const newUser = await this.prisma.user.create({


### PR DESCRIPTION
## WHAT
- LikedTag table added
- Spelling error "linkedin" fixed
- `.git-commit-template` updated
- `PULL_REQUEST_TEMPLATE.md` updated

## WHY
Complete the MVP with the tag liking functionality planned for V1.
Correction of the spelling of "linkedin" to fix the problem encountered on the front of the impossibility of registering a professional user.
Concerning the templates, this is to have more documentation and that it is up to date with our organisation on Jira.

## HOW
- LikedTag table created in schema.prisma (changes pushed to DB)
- LikedTag service, controller and module created
- LikedTagModule added in app.module.ts
- In userData.dto and user.service error likendin replaced by linkedin
- Test with Swagger OK
- `.git-commit-template` updated with inclusion of Jira issue instead of Github issue
- Checkbox for "Automatically tested", and sections "TODO", "Bonus" and "Annex" added in PR template

### Link to Jira ticket
YL-19
---

## Checklist
- [x] Tested
- [ ] Automatically tested
- [ ] Documented or commented
- [x] Search for duplicates code or PRs or issues
- [ ] Blocked
- [ ] WIP
---

## Blocked
N/A

## WIP
N/A

## TODO
- Management of the storage of _Linkedin_ recommendations and verification of the pro user's recommended skills on creation
- Types and dto of liked categories and liked tags

## Bonus
Settings for Github autolink references to Jira tickets.

## Annex
For settings of Autolink references :
![2025-02-18_20h38_06](https://github.com/user-attachments/assets/b45f8d5c-439c-47ad-ab55-a078e0bca058)

## Resources
[Autolink-references-in-GitHub](https://community.atlassian.com/t5/Jira-articles/Autolink-references-in-GitHub/ba-p/1898857)